### PR TITLE
Add support for the 'artifactory' context in the digital-asset repo.

### DIFF
--- a/src/scripts/prep.sh
+++ b/src/scripts/prep.sh
@@ -56,7 +56,7 @@ fi
 
 # always run as root
 if [ ${EUID} == 0 ]; then
-  main "${ORB_VERSION}" "${ARTIFACTORY_USER:-}" "${ARTIFACTORY_PASSWORD:-}"
+  main "${ORB_VERSION}" "${ARTIFACTORY_USER:-}" "${ARTIFACTORY_PASSWORD:-${ARTIFACTORY_TOKEN:-}}"
 else
-  sudo bash -c "$(declare -f main); main \"${ORB_VERSION}\" \"${ARTIFACTORY_USER:-}\" \"${ARTIFACTORY_PASSWORD:-}\""
+  sudo bash -c "$(declare -f main); main \"${ORB_VERSION}\" \"${ARTIFACTORY_USER:-}\" \"${ARTIFACTORY_PASSWORD:-${ARTIFACTORY_TOKEN:-}}\""
 fi


### PR DESCRIPTION
The `artifactory` context in the github.com/digital-asset organization was set up ever so subtly differently (defining an environment variable called `ARTIFACTORY_TOKEN` instead of `ARTIFACTORY_PASSWORD`), so adjust the script so that the nix environment looks for configuration in either variable name.